### PR TITLE
Implement basic API with database models

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 This is aiogram(aiogram + FastAPi webhook) template
 
 
-install everything:
-```pip install -r requirements.txt```
+Install everything:
+```bash
+pip install -r requirements.txt
+```
+
+Run the application with uvicorn:
+```bash
+uvicorn bot.main:app --reload
+```
+
+### API overview
+
+- `POST /api/register` – create or update a user
+- `POST /api/orders` – create an order for a user
+- `POST /api/orders/{tracking}` – update order status/weight
+- `GET /api/orders/{user_id}` – list user orders
+- `GET /api/addresses/{user_id}` – list user addresses
+- `POST /api/addresses` – add a new address
 

--- a/bot/db/database.py
+++ b/bot/db/database.py
@@ -1,0 +1,10 @@
+from tortoise import Tortoise
+
+
+async def init_db(db_url: str = "sqlite://db.sqlite3"):
+    await Tortoise.init(db_url=db_url, modules={"models": ["bot.db.models"]})
+    await Tortoise.generate_schemas()
+
+
+async def close_db():
+    await Tortoise.close_connections()

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -1,0 +1,38 @@
+from enum import Enum
+from tortoise import fields
+from tortoise.models import Model
+
+
+class OrderStatus(str, Enum):
+    ordered = "ordered"
+    received_in_china = "received_in_china"
+    in_transit = "in_transit"
+    arrived_in_uzbekistan = "arrived_in_uzbekistan"
+    ready_for_pickup = "ready_for_pickup"
+
+
+class User(Model):
+    id = fields.IntField(pk=True)
+    telegram_id = fields.BigIntField(unique=True)
+    first_name = fields.CharField(max_length=255, null=True)
+    last_name = fields.CharField(max_length=255, null=True)
+    phone_number = fields.CharField(max_length=50, null=True)
+
+    orders: fields.ReverseRelation["Order"]
+    addresses: fields.ReverseRelation["Address"]
+
+
+class Address(Model):
+    id = fields.IntField(pk=True)
+    user = fields.ForeignKeyField("models.User", related_name="addresses")
+    address = fields.TextField()
+    is_default = fields.BooleanField(default=False)
+
+
+class Order(Model):
+    id = fields.IntField(pk=True)
+    user = fields.ForeignKeyField("models.User", related_name="orders")
+    tracking_number = fields.CharField(max_length=255, unique=True)
+    status = fields.CharEnumField(OrderStatus, default=OrderStatus.ordered)
+    weight = fields.FloatField(null=True)
+    created_at = fields.DatetimeField(auto_now_add=True)

--- a/bot/handlers/user_flow.py
+++ b/bot/handlers/user_flow.py
@@ -1,0 +1,17 @@
+from aiogram import Router, types
+from aiogram.filters import Command
+from bot.db.models import User
+
+user_router = Router()
+
+
+@user_router.message(Command("start"))
+async def cmd_start(message: types.Message):
+    user, _ = await User.get_or_create(
+        telegram_id=message.from_user.id,
+        defaults={
+            "first_name": message.from_user.first_name,
+            "last_name": message.from_user.last_name,
+        },
+    )
+    await message.answer(f"Hello, your internal ID is {user.id}")

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,13 +1,43 @@
 import asyncio
+from enum import Enum
+from typing import List
+
 from aiogram import Bot, Dispatcher
 from aiogram.client.bot import DefaultBotProperties
-from bot.config import BOT_TOKEN, WEBHOOK_PATH,WEBHOOK_URL
-from handlers.user_flow import user_router
-from bot.middlewares import LoggingMiddleware
-from fastapi import FastAPI, Request,Response
-from contextlib import asynccontextmanager
-from aiogram.webhook.aiohttp_server import setup_application
 from aiogram.types import Update
+from fastapi import FastAPI, Request, Response
+from pydantic import BaseModel
+from contextlib import asynccontextmanager
+
+from bot.config import BOT_TOKEN, WEBHOOK_PATH, WEBHOOK_URL
+from handlers.user_flow import user_router
+from bot.db.database import init_db, close_db
+from bot.db import models
+
+
+class UserCreate(BaseModel):
+    telegram_id: int
+    first_name: str | None = None
+    last_name: str | None = None
+    phone_number: str | None = None
+
+
+class AddressCreate(BaseModel):
+    user_id: int
+    address: str
+    is_default: bool = False
+
+
+class OrderCreate(BaseModel):
+    user_id: int
+    tracking_number: str
+    status: models.OrderStatus = models.OrderStatus.ordered
+    weight: float | None = None
+
+
+class OrderUpdate(BaseModel):
+    status: models.OrderStatus | None = None
+    weight: float | None = None
 
 
 
@@ -28,19 +58,93 @@ dp.include_router(user_router)
 
 # ✅ Lifespan: startup and shutdown logic
 @asynccontextmanager
-async def lifespan(app:FastAPI):
+async def lifespan(app: FastAPI):
+    await init_db()
     await bot.set_webhook(url=WEBHOOK_URL)
     print("🔗 Webhook set:", WEBHOOK_URL)
     print("WEBHOOK_PATH:", WEBHOOK_PATH)
-    yield
-    await bot.delete_webhook()
-    print("❌ Webhook deleted")
+    try:
+        yield
+    finally:
+        await bot.delete_webhook()
+        await close_db()
+        print("❌ Webhook deleted")
 
 
 
 
 # Create FastAPI app with webhook lifespan manager
 app = FastAPI(lifespan=lifespan)
+
+
+@app.post("/api/register")
+async def register_user(data: UserCreate):
+    user, created = await models.User.get_or_create(
+        telegram_id=data.telegram_id, defaults=data.model_dump()
+    )
+    if not created:
+        await user.update_from_dict(data.model_dump()).save()
+    return {"id": user.id, "telegram_id": user.telegram_id}
+
+
+@app.post("/api/orders")
+async def create_order(data: OrderCreate):
+    user = await models.User.get(id=data.user_id)
+    order = await models.Order.create(
+        user=user,
+        tracking_number=data.tracking_number,
+        status=data.status,
+        weight=data.weight,
+    )
+    return {"order_id": order.id}
+
+
+@app.post("/api/orders/{tracking_number}")
+async def update_order(tracking_number: str, data: OrderUpdate):
+    order = await models.Order.get_or_none(tracking_number=tracking_number)
+    if order is None:
+        return Response(status_code=404)
+    if data.status is not None:
+        order.status = data.status
+    if data.weight is not None:
+        order.weight = data.weight
+    await order.save()
+    return {"status": "updated"}
+
+
+@app.get("/api/orders/{user_id}")
+async def list_orders(user_id: int):
+    user = await models.User.get(id=user_id)
+    await user.fetch_related("orders")
+    orders = [
+        {
+            "tracking_number": o.tracking_number,
+            "status": o.status,
+            "weight": o.weight,
+        }
+        for o in user.orders
+    ]
+    return {"orders": orders}
+
+
+@app.get("/api/addresses/{user_id}")
+async def list_addresses(user_id: int):
+    user = await models.User.get(id=user_id)
+    await user.fetch_related("addresses")
+    addresses = [
+        {"id": a.id, "address": a.address, "is_default": a.is_default}
+        for a in user.addresses
+    ]
+    return {"addresses": addresses}
+
+
+@app.post("/api/addresses")
+async def add_address(data: AddressCreate):
+    user = await models.User.get(id=data.user_id)
+    addr = await models.Address.create(
+        user=user, address=data.address, is_default=data.is_default
+    )
+    return {"address_id": addr.id}
 
 
 


### PR DESCRIPTION
## Summary
- set up Tortoise ORM models for `User`, `Order`, and `Address`
- initialize database during FastAPI startup
- create FastAPI endpoints for registering users, managing orders and addresses
- implement a simple `/start` command handler
- document setup and API usage in the README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6847fc931dbc8322b509094def02d049